### PR TITLE
Make project slugs user specific.

### DIFF
--- a/config/Migrations/20210316024149_UserSpecificProjectSlug.php
+++ b/config/Migrations/20210316024149_UserSpecificProjectSlug.php
@@ -10,6 +10,7 @@ class UserSpecificProjectSlug extends AbstractMigration
      *
      * More information on this method is available here:
      * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
+     *
      * @return void
      */
     public function change()

--- a/config/Migrations/20210316024149_UserSpecificProjectSlug.php
+++ b/config/Migrations/20210316024149_UserSpecificProjectSlug.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+use Migrations\AbstractMigration;
+
+class UserSpecificProjectSlug extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
+     * @return void
+     */
+    public function change()
+    {
+        $this->table('projects')
+            ->addIndex(['user_id', 'slug'], ['unique' => true])
+            ->save();
+    }
+}

--- a/src/Controller/ProjectSectionsController.php
+++ b/src/Controller/ProjectSectionsController.php
@@ -16,8 +16,11 @@ class ProjectSectionsController extends AppController
 {
     protected function getProject(string $slug): Project
     {
+        $query = $this->ProjectSections->Projects->findBySlug($slug);
+        $query = $this->Authorization->applyScope($query, 'index');
+
         /** @var \App\Model\Entity\Project */
-        return $this->ProjectSections->Projects->findBySlug($slug)->firstOrFail();
+        return $query->firstOrFail();
     }
 
     public function add(string $projectSlug)

--- a/src/Controller/ProjectsController.php
+++ b/src/Controller/ProjectsController.php
@@ -22,8 +22,11 @@ class ProjectsController extends AppController
 
     protected function getProject($slug, array $contain = []): Project
     {
+        $query = $this->Projects->findBySlug($slug);
+        $query = $this->Authorization->applyScope($query, 'index');
+
         /** @var \App\Model\Entity\Project */
-        return $this->Projects->findBySlug($slug)
+        return $query
             ->contain($contain)
             ->firstOrFail();
     }
@@ -36,7 +39,6 @@ class ProjectsController extends AppController
     public function view(string $slug)
     {
         $project = $this->getProject($slug, ['Sections']);
-        $this->Authorization->authorize($project);
 
         $query = $this->Authorization
             ->applyScope($this->Tasks->find(), 'index')

--- a/src/Model/Behavior/SluggableBehavior.php
+++ b/src/Model/Behavior/SluggableBehavior.php
@@ -148,6 +148,7 @@ class SluggableBehavior extends Behavior
     public function slug($string)
     {
         $length = $this->getConfig('length');
+
         return substr(strtolower(Text::slug($string)), 0, $length);
     }
 }

--- a/src/Model/Behavior/SluggableBehavior.php
+++ b/src/Model/Behavior/SluggableBehavior.php
@@ -19,6 +19,7 @@ use Cake\Event\Event;
 use Cake\Log\LogTrait;
 use Cake\ORM\Behavior;
 use Cake\Utility\Text;
+use RuntimeException;
 
 /**
  * Model behavior to support generation of slugs for models.
@@ -28,14 +29,14 @@ class SluggableBehavior extends Behavior
     use LogTrait;
 
     /**
-     * Initiate behavior for the model using specified settings. Available settings:
+     * Initial behavior for the model using specified settings. Available settings:
      *
      * - label: (array | string, optional) set to the field name that contains the
      * string from where to generate the slug, or a set of field names to
      * concatenate for generating the slug. DEFAULTS TO: title
      *
      * - slug: (string, optional) name of the field name that holds generated slugs.
-     * DEFAULTS TO: slug
+     * Defaults to: `slug`
      *
      * - separator: (string, optional) separator character / string to use for replacing
      * non alphabetic characters in generated slug. DEFAULTS TO: -
@@ -48,6 +49,9 @@ class SluggableBehavior extends Behavior
      *
      * - reserved: (string[]) A list of values that cannot be used as a slug.
      *
+     * - scopeFields: (string[]) A list of fields that create 'scopes' for slugs.
+     *   In your table's schema each scope + slug field should have a unique index.
+     *
      * @var array
      */
     protected $_defaultConfig = [
@@ -57,6 +61,7 @@ class SluggableBehavior extends Behavior
         'length' => 100,
         'overwrite' => true,
         'reserved' => [],
+        'scopeFields' => [],
         'implementedMethods' => [
             'slug' => 'slug',
         ],
@@ -69,11 +74,11 @@ class SluggableBehavior extends Behavior
     {
         // Make label fields an array
         if (!is_array($this->_config['label'])) {
-            $this->_config['label'] = [$this->_config['label']];
+            throw new RuntimeException('`label` option must be an array.');
         }
 
-        $alias = $this->_table->getAlias();
-        $pk = (array)$this->_table->getPrimaryKey();
+        $table = $this->table();
+        $pk = (array)$table->getPrimaryKey();
         $pk = $pk[0];
 
         // See if we should be generating a slug
@@ -92,33 +97,35 @@ class SluggableBehavior extends Behavior
             }
 
             // Get the slug
-            $slug = $this->slug($label, $this->getConfig());
+            $slug = $this->slug($label);
 
             // Look for slugs that start with the same slug we've just generated
-            $conditions = [$alias . '.' . $this->getConfig('slug') . ' LIKE' => $slug . '%'];
-
+            // Exclude the current record if we are doing an update and apply scope conditions.
+            $conditions = [$table->aliasField($this->getConfig('slug')) . ' LIKE' => $slug . '%'];
             if (!empty($entity[$pk])) {
-                $conditions[$alias . '.' . $pk . ' !='] = $entity[$pk];
+                $conditions[$table->aliasField($pk) . ' !='] = $entity->get($pk);
+            }
+            foreach ($this->getConfig('scopeFields') as $scope) {
+                $conditions[$table->aliasField($scope)] = $entity->get($scope);
             }
 
-            $result = $this->_table->find('all', [
-                'conditions' => $conditions,
-                'fields' => [$pk, $this->getConfig('slug')],
-            ]);
+            $result = $table->find()
+                ->select([$pk, $this->getConfig('slug')])
+                ->where($conditions);
             $sameUrls = $result->extract($this->getConfig('slug'))->toArray();
 
             $accepted = !empty($sameUrls) || !in_array($slug, $this->getConfig('reserved'));
 
             // If we have collisions
             if (!$accepted) {
-                $begginingSlug = $slug;
+                $beginningSlug = $slug;
                 $index = 1;
 
                 // Attach an ending incremental number until we find a free slug
 
                 while ($index > 0) {
-                    if (!in_array($begginingSlug . $this->getConfig('separator') . $index, $sameUrls)) {
-                        $slug = $begginingSlug . $this->getConfig('separator') . $index;
+                    if (!in_array($beginningSlug . $this->getConfig('separator') . $index, $sameUrls)) {
+                        $slug = $beginningSlug . $this->getConfig('separator') . $index;
                         $index = -1;
                     }
 
@@ -135,12 +142,12 @@ class SluggableBehavior extends Behavior
      * Generate a slug for the given string using specified settings.
      *
      * @param string $string String from where to generate slug
-     * @param array $settings Settings to use (looks for 'separator' and 'length')
      * @return string Slug for given string
      * @access private
      */
-    public function slug($string, $settings)
+    public function slug($string)
     {
-        return strtolower(Text::slug($string));
+        $length = $this->getConfig('length');
+        return substr(strtolower(Text::slug($string)), 0, $length);
     }
 }

--- a/src/Model/Table/ProjectsTable.php
+++ b/src/Model/Table/ProjectsTable.php
@@ -74,6 +74,7 @@ class ProjectsTable extends Table
         $this->addBehavior('Sluggable', [
             'label' => ['name'],
             'reserved' => ['archived', 'add'],
+            'scopeFields' => ['user_id'],
         ]);
     }
 

--- a/tests/Fixture/ProjectsFixture.php
+++ b/tests/Fixture/ProjectsFixture.php
@@ -33,6 +33,7 @@ class ProjectsFixture extends TestFixture
         ],
         '_constraints' => [
             'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
+            'projects_unique_slug' => ['type' => 'unique', 'columns' => ['user_id', 'slug']],
             'projects_ibfk_1' => ['type' => 'foreign', 'columns' => ['user_id'], 'references' => ['users', 'id'], 'update' => 'restrict', 'delete' => 'cascade', 'length' => []],
         ],
     ];

--- a/tests/TestCase/Controller/ProjectSectionsControllerTest.php
+++ b/tests/TestCase/Controller/ProjectSectionsControllerTest.php
@@ -68,7 +68,7 @@ class ProjectSectionsControllerTest extends TestCase
         $this->post("/projects/{$project->slug}/sections", [
             'name' => 'Day Trips',
         ]);
-        $this->assertResponseCode(403);
+        $this->assertResponseCode(404);
 
         $count = $this->ProjectSections->find()->count();
         $this->assertEquals(0, $count);
@@ -119,7 +119,7 @@ class ProjectSectionsControllerTest extends TestCase
         $this->post("/projects/{$project->slug}/sections/{$section->id}/edit", [
             'name' => 'Reading list',
         ]);
-        $this->assertResponseCode(403);
+        $this->assertResponseCode(404);
     }
 
     public function testEditValidationFailure()
@@ -175,7 +175,7 @@ class ProjectSectionsControllerTest extends TestCase
         $this->login();
         $this->enableCsrfToken();
         $this->post("/projects/{$project->slug}/sections/{$section->id}/archive");
-        $this->assertResponseCode(403);
+        $this->assertResponseCode(404);
     }
 
     public function testUnarchive()
@@ -202,7 +202,7 @@ class ProjectSectionsControllerTest extends TestCase
         $this->login();
         $this->enableCsrfToken();
         $this->post("/projects/{$project->slug}/sections/{$section->id}/unarchive");
-        $this->assertResponseCode(403);
+        $this->assertResponseCode(404);
     }
 
     public function testDelete()
@@ -227,7 +227,7 @@ class ProjectSectionsControllerTest extends TestCase
         $this->login();
         $this->enableCsrfToken();
         $this->post("/projects/{$project->slug}/sections/{$section->id}/delete");
-        $this->assertResponseCode(403);
+        $this->assertResponseCode(404);
     }
 
     public function testDeleteUpdateTasks()
@@ -262,7 +262,7 @@ class ProjectSectionsControllerTest extends TestCase
         $this->post("/projects/{$project->slug}/sections/{$section->id}/move", [
             'ranking' => 0,
         ]);
-        $this->assertResponseCode(403);
+        $this->assertResponseCode(404);
     }
 
     public function testMoveNoData()


### PR DESCRIPTION
This allows multiple users to have overlapping slugs without prefixing the slugs leaking how many users have the same slug.