### PR TITLE
Add project move menu

### DIFF
--- a/assets/js/actions/tasks.tsx
+++ b/assets/js/actions/tasks.tsx
@@ -5,7 +5,7 @@ import {UpdaterCallback, UpdateData} from 'app/components/taskGroupedSorter';
 
 export function updateTask(
   task: Task,
-  data: FormData | Partial<Record<keyof Task, string | number | null | boolean>>
+  data: FormData | Partial<Record<string, string | number | null | boolean>>
 ): Promise<AxiosResponse<undefined>> {
   return axios.post(`/tasks/${task.id}/edit`, data);
 }

--- a/assets/sass/_variables.scss
+++ b/assets/sass/_variables.scss
@@ -134,7 +134,7 @@ body {
   --color-toggle-checked: var(--color-ochre-300);
 
   --color-action-edit: var(--color-ochre-700);
-  --color-action-delete: var(--color-red-700);
+  --color-action-delete: var(--color-red-500);
   --color-action-complete: var(--color-green-700);
 
   --color-due-none: var(--color-gray-600);

--- a/assets/sass/components/dropdownMenu.scss
+++ b/assets/sass/components/dropdownMenu.scss
@@ -46,6 +46,13 @@
   text-decoration: none;
 }
 
+.dropdown-item-header {
+  line-height: 1.2;
+
+  padding: $space $space * 1.5;
+  margin: 0;
+}
+
 [data-reach-menu-item] {
   &[data-selected],
   &:hover {
@@ -64,6 +71,9 @@
   }
   &.archive svg {
     color: var(--color-low-emphasis);
+  }
+  &.calendar svg {
+    color: var(--color-due-today);
   }
   &.edit svg {
     color: var(--color-action-edit);


### PR DESCRIPTION
Move reschedule to a single menu alongside the new move action.
This makes sorting tasks easier as project & date edits can be done with
fewer clicks than the edit view needs.